### PR TITLE
Check localstore for token and re-authenticate user if necessary befo…

### DIFF
--- a/src/components/routing/PrivateRoute.js
+++ b/src/components/routing/PrivateRoute.js
@@ -17,9 +17,18 @@ const PrivateRoute = ({ component: Component, ...rest }) => {
         M.AutoInit()
     })
 
+    
     const authContext = useContext(AuthContext)
     //console.log(authContext)
-    const { isAuthenticated, loading } = authContext;
+    const { isAuthenticated, loading, getUser } = authContext;
+    
+    useEffect(() => {
+        // Check for token and update application state if required
+        const token = localStorage.getItem('token');
+        if (token && !isAuthenticated) {
+          getUser();
+        }
+      }, []);
 
     return (
         // Show the component only when the user is authenticated


### PR DESCRIPTION
Whenever the page was refreshed the authState would get reset to the initial state with isAuthenticated set to false. To fix this I added a filter on the privateRoute component which checks if there is a jwt in local storage and re-authenticates if necessary. 